### PR TITLE
Undo localhost api endpoint client

### DIFF
--- a/internal/swagger/configuration.go
+++ b/internal/swagger/configuration.go
@@ -59,7 +59,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://localhost:8080",
+		BasePath:      "https://api.cloud.getoctane.io",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 	}


### PR DESCRIPTION
Flip the default SDK server back to production instead of localhost.