### PR TITLE
fix empty price credit grant

### DIFF
--- a/internal/swagger/model_create_credit_grant_args.go
+++ b/internal/swagger/model_create_credit_grant_args.go
@@ -23,5 +23,5 @@ type CreateCreditGrantArgs struct {
 	// Optional description. This is only viewable internally
 	Description string `json:"description,omitempty"`
 	// Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified
-	Price *int32 `json:"price,omitempty"`
+	Price int32 `json:"price"`
 }

--- a/internal/swagger/model_create_credit_grant_args.go
+++ b/internal/swagger/model_create_credit_grant_args.go
@@ -23,5 +23,5 @@ type CreateCreditGrantArgs struct {
 	// Optional description. This is only viewable internally
 	Description string `json:"description,omitempty"`
 	// Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified
-	Price int32 `json:"price,omitempty"`
+	Price *int32 `json:"price,omitempty"`
 }

--- a/octane_api_credits.go
+++ b/octane_api_credits.go
@@ -20,7 +20,7 @@ type (
 		// Optional description. This is only viewable internally
 		Description string `json:"description,omitempty"`
 		// Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified
-		Price *int32 `json:"price,omitempty"`
+		Price int32 `json:"price"`
 	}
 
 	creditsAPI struct {

--- a/octane_api_credits.go
+++ b/octane_api_credits.go
@@ -20,7 +20,7 @@ type (
 		// Optional description. This is only viewable internally
 		Description string `json:"description,omitempty"`
 		// Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified
-		Price int32 `json:"price,omitempty"`
+		Price *int32 `json:"price,omitempty"`
 	}
 
 	creditsAPI struct {


### PR DESCRIPTION
omitempty in golang with the zero value for an int32 is treated as empty